### PR TITLE
Fix: "Correctly determine the original size of a compressed source data."

### DIFF
--- a/src/gw_sys/gw_romloader.c
+++ b/src/gw_sys/gw_romloader.c
@@ -163,7 +163,7 @@ bool gw_romloader_rom2ram()
    else if (memcmp(src, LZ4_MAGIC, 4) == 0)
    {
       printf("ROM LZ4 detected\n");
-      rom_size_compressed_src = lz4_get_file_size(src);
+      rom_size_compressed_src = lz4_get_original_size(src);
 
       rom_size_src = lz4_uncompress(src, dest);
 


### PR DESCRIPTION
Original code was using an **unreferenced function** `lz4_get_file_size`. This has now been fixed..

Specifically, the `lz4_get_original_size()` function is being called with the compressed src data as an input, and it returns the original (uncompressed) size of the data that was compressed to create src. The result is then assigned to the rom_size_compressed_src variable.

